### PR TITLE
Add button to hide or show search/buttons panel

### DIFF
--- a/havelock_backend_theme/views.xml
+++ b/havelock_backend_theme/views.xml
@@ -13,6 +13,7 @@
 
  		 <template id="menu_webclient_bootstrap_havelock_backend_theme" inherit_id="web.webclient_bootstrap">
             <xpath expr="//div[@class='navbar-header']" position="inside">
+                <button type="button" class="navbar-toggle btn-link fa fa-search fa-lg" onclick="$('.o_control_panel').toggleClass('hidden');"/>
                 <ul class="ul_toggle_leftmenu">
                     <li class="btn-link toggle_leftmenu">
                          <span class="fa fa-bars fa-lg"></span>
@@ -25,4 +26,3 @@
 
     </data>
 </odoo>
-

--- a/shamrock_backend_theme/views.xml
+++ b/shamrock_backend_theme/views.xml
@@ -10,19 +10,19 @@
                 <script type="text/javascript" src="/shamrock_backend_theme/static/src/js/toggle_leftbar.js"></script>
             </xpath>
         </template>
-        
+
  		 <template id="menu_webclient_bootstrap_dewanukm_backend_theme" inherit_id="web.webclient_bootstrap">
             <xpath expr="//div[@class='navbar-header']" position="inside">
+                <button type="button" class="navbar-toggle btn-link fa fa-search fa-lg" onclick="$('.o_control_panel').toggleClass('hidden');"/>
                 <ul class="ul_toggle_leftmenu">
                     <li class="btn-link toggle_leftmenu">
                          <span class="fa fa-bars fa-lg"></span>
                     </li>
                 </ul>
             </xpath>
-            
+
         </template>
 
 
     </data>
 </odoo>
-


### PR DESCRIPTION
On small screens (mobile phones) adds a button on the top bar that allows to hide or show the 'control panel' (the search and buttons panel). That panel is not scrollable, so on mobile phones only about two thirds of the screen are available to display and scroll the current form/list. With this modification, a new button allows to minimize the panel so we can leave only the top bar and the form/list contents on the screen.

Original:
![imagen](https://user-images.githubusercontent.com/1407768/27131906-1cfabf1e-510d-11e7-831d-f161e7c0be44.png)

Improved with panel hidden (after clicking on the search button on top):
![imagen](https://user-images.githubusercontent.com/1407768/27131913-25f09a94-510d-11e7-8925-b05f3b78f529.png)
